### PR TITLE
Ad Tracking + Error Tracking Fixes + videoChange Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
     "global": "^4.3.0",
-    "mux-embed": "^2.8.0",
+    "mux-embed": "^3.0.0",
     "npm-run-all": "^2.2.0",
     "path": "^0.12.7",
     "sinon": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -7,7 +7,7 @@ var app = {
       debug: true,
       automaticVideoChange: true,
       data: {
-        env_key: 'ikh9lsia6bh8pj5get2vnt6hm', // JW Testing
+        env_key: 'YOUR_ENV_KEY',
         player_init_time: Date.now(),
         experiment_name: 'automaticVideoChange enabled'
       }

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -6,7 +6,7 @@ var app = {
     initChromecastMux(playerManager, {
       debug: true,
       data : {
-        env_key: '[YOUR ENVIRONMENT KEY]',
+        env_key: 'ikh9lsia6bh8pj5get2vnt6hm', // JW Testing
         player_init_time: Date.now(),
       }
     });

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -5,9 +5,11 @@ var app = {
 
     initChromecastMux(playerManager, {
       debug: true,
-      data : {
+      automaticVideoChange: true,
+      data: {
         env_key: 'ikh9lsia6bh8pj5get2vnt6hm', // JW Testing
         player_init_time: Date.now(),
+        experiment_name: 'automaticVideoChange enabled'
       }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ const monitorChromecastPlayer = function (player, options) {
   let videoChanged = false;
   let isSeeking = false;
   let inAdBreak = false;
+  let stats = new cast.framework.Stats();
 
   // Return current playhead time in milliseconds
   options.getPlayheadTime = () => {
@@ -172,9 +173,8 @@ const monitorChromecastPlayer = function (player, options) {
         case cast.framework.events.EventType.TIME_UPDATE:
           currentTime = event.currentMediaTime;
           player.mux.emit('timeupdate');
-          let stats = new cast.framework.Stats();
 
-          console.log('STATS' + JSON.stringify(stats));
+          console.log('STATS: ' + JSON.stringify(stats));
           break;
         case cast.framework.events.EventType.SEGMENT_DOWNLOADED:
           let now = Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,7 @@ const monitorChromecastPlayer = function (player, options) {
           videoChanged = false;
           break;
         case cast.framework.events.EventType.MEDIA_STATUS:
-          console.log('Stats: ' + cast.framework.Stats.width + ' ' + cast.framework.Stats.height);
-          console.log('Video Information: ' + cast.framework.messages.VideoInformation.width + ' ' + cast.framework.messages.VideoInformation.height);
+          console.log('mediaStatus: ' + event.mediaStatus + ' ' + event.mediaStatus.videoInfo);
           if (event.mediaStatus.videoInfo !== undefined) {
             // Note: it appears the videoInfo field is always undefined
             videoSourceWidth = event.mediaStatus.videoInfo.width;
@@ -219,6 +218,7 @@ const monitorChromecastPlayer = function (player, options) {
   player.addEventListener(cast.framework.events.category.CORE, player.muxListener);
   player.addEventListener(cast.framework.events.category.FINE, player.muxListener);
   player.addEventListener(cast.framework.events.category.DEBUG, player.muxListener);
+  player.addEventListener(cast.framework.Stats, player.muxListener);
 
   // Lastly, initialize the tracking
   mux.init(playerID, options);

--- a/src/index.js
+++ b/src/index.js
@@ -205,8 +205,7 @@ const monitorChromecastPlayer = function (player, options) {
           break;
         case cast.framework.events.EventType.BREAK_CLIP_ENDED:
           player.mux.emit('adended');
-          log.info('ENDED EVENT');
-          log.info(event);
+          log.info('[mux] ENDED REASON: ' + event.endedReason);
           break;
         case cast.framework.events.EventType.BREAK_ENDED:
           player.mux.emit('adbreakend');

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,6 @@ const monitorChromecastPlayer = function (player, options) {
   player.addEventListener(cast.framework.events.category.CORE, player.muxListener);
   player.addEventListener(cast.framework.events.category.FINE, player.muxListener);
   player.addEventListener(cast.framework.events.category.DEBUG, player.muxListener);
-  player.addEventListener(cast.framework.Stats, player.muxListener);
 
   // Lastly, initialize the tracking
   mux.init(playerID, options);

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,8 @@ const monitorChromecastPlayer = function (player, options) {
           if (!options.automaticErrorTracking) { return; }
           player.mux.emit('error', {
             player_error_code: event.detailedErrorCode,
-            player_error_message: event.error ? JSON.stringify(event.error) : 'Unknown Error'
+            // player_error_message: event.error ? JSON.stringify(event.error) : 'Unknown Error'
+            player_error_message: event.reason
           });
           break;
         case cast.framework.events.EventType.RATE_CHANGE:

--- a/src/index.js
+++ b/src/index.js
@@ -220,6 +220,9 @@ const monitorChromecastPlayer = function (player, options) {
   player.addEventListener(cast.framework.events.category.CORE, player.muxListener);
   player.addEventListener(cast.framework.events.category.FINE, player.muxListener);
   player.addEventListener(cast.framework.events.category.DEBUG, player.muxListener);
+  var stats = new cast.framework.Stats();
+
+  console.log(stats);
 
   // Lastly, initialize the tracking
   mux.init(playerID, options);

--- a/src/index.js
+++ b/src/index.js
@@ -226,8 +226,9 @@ const monitorChromecastPlayer = function (player, options) {
           if (adBreakClips !== null && event.breakClipId !== undefined) {
             let obj = adBreakClips.find(o => o.id === event.breakClipId);
 
-            const adTagUrl = obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined ? obj.vastAdsRequest.adTagUrl : undefined;
-            const adAssetUrl = obj.contentUrl !== undefined ? obj.contentUrl : undefined;
+            var adAssetUrl = obj.contentUrl !== undefined ? obj.contentUrl : undefined;
+
+            if (obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined) { var adTagUrl = obj.vastAdsRequest.adTagUrl; } else { adTagUrl === undefined; }
 
             player.mux.emit('adplay', {
               ad_asset_url: adAssetUrl,

--- a/src/index.js
+++ b/src/index.js
@@ -78,12 +78,6 @@ const monitorChromecastPlayer = function (player, options) {
     log.info('MuxCast: event ', event);
     if (inAdBreak === false) {
       switch (event.type) {
-        case cast.framework.messages.VideoInformation:
-          console.log('Video Information: ' + cast.framework.messages.VideoInformation);
-          break;
-        case cast.framework.Stats:
-          console.log('Stats: ' + cast.framework.Stats);
-          break;
         case cast.framework.events.EventType.REQUEST_LOAD:
           if (event.requestData.media !== undefined) {
             if (event.requestData.media.contentId !== undefined) {
@@ -125,6 +119,8 @@ const monitorChromecastPlayer = function (player, options) {
           videoChanged = false;
           break;
         case cast.framework.events.EventType.MEDIA_STATUS:
+          console.log('Stats: ' + cast.framework.Stats);
+          console.log('Video Information: ' + cast.framework.messages.VideoInformation);
           if (event.mediaStatus.videoInfo !== undefined) {
             // Note: it appears the videoInfo field is always undefined
             videoSourceWidth = event.mediaStatus.videoInfo.width;

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ const monitorChromecastPlayer = function (player, options) {
   let videoChanged = false;
   let isSeeking = false;
   let inAdBreak = false;
+  let adPlaying = false;
 
   // Return current playhead time in milliseconds
   options.getPlayheadTime = () => {
@@ -219,12 +220,23 @@ const monitorChromecastPlayer = function (player, options) {
         case cast.framework.events.EventType.BREAK_CLIP_LOADING:
           player.mux.emit('adplay');
           break;
+        case cast.framework.events.EventType.PLAY: // cater for playback events within ad breaks, not captured by BREAK_ events
+          if (adPlaying) { player.mux.emit('adplay'); };
+          break;
+        case cast.framework.events.EventType.PAUSE: // cater for playback events within ad breaks, not captured by BREAK_ events
+          if (adPlaying) { player.mux.emit('adpause'); };
+          break;
         case cast.framework.events.EventType.BREAK_CLIP_STARTED:
           player.mux.emit('adplaying');
+          adPlaying = true;
+          break;
+        case cast.framework.events.EventType.PLAYING: // cater for playback events within ad breaks, not captured by BREAK_ events
+          if (adPlaying) { player.mux.emit('adplaying'); };
           break;
         case cast.framework.events.EventType.BREAK_CLIP_ENDED:
           if (event.endedReason && event.endedReason === 'ERROR') { player.mux.emit('aderror'); };
           player.mux.emit('adended');
+          adPlaying = false;
           break;
         case cast.framework.events.EventType.BREAK_ENDED:
           player.mux.emit('adbreakend');

--- a/src/index.js
+++ b/src/index.js
@@ -194,8 +194,8 @@ const monitorChromecastPlayer = function (player, options) {
     if (inAdBreak === true) {
       // Ad Events
       // adpause event not present in chromecast documentation
-      // chromecast will mix player messages with ad messages, which screws us up right now
-      // seperating out these ad events and using inAdBreak to supress other messages until the adbreak is over
+      // chromecast will mix player messages with ad messages
+      // seperating out these ad events and supressing other messages until the adbreak is over
       switch (event.type) {
         case cast.framework.events.EventType.BREAK_CLIP_LOADING:
           player.mux.emit('adplay');
@@ -204,7 +204,8 @@ const monitorChromecastPlayer = function (player, options) {
           player.mux.emit('adplaying');
           break;
         case cast.framework.events.EventType.BREAK_CLIP_ENDED:
-          event.endedReason && event.endedReason === 'ERROR' ? player.mux.emit('aderror') : player.mux.emit('adended');
+          if (event.endedReason && event.endedReason === 'ERROR') { player.mux.emit('aderror'); };
+          player.mux.emit('adended');
           break;
         case cast.framework.events.EventType.BREAK_ENDED:
           player.mux.emit('adbreakend');

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ const monitorChromecastPlayer = function (player, options) {
       player_is_paused: isPaused,
       video_source_width: videoSourceWidth,
       video_source_height: videoSourceHeight,
-
+      video_title: title,
       player_autoplay_on: autoplay,
       player_preload_on: undefined,
       video_source_url: mediaUrl,

--- a/src/index.js
+++ b/src/index.js
@@ -160,8 +160,8 @@ const monitorChromecastPlayer = function (player, options) {
           if (!options.automaticErrorTracking) { return; }
           player.mux.emit('error', {
             player_error_code: event.detailedErrorCode,
-            // player_error_message: event.error ? JSON.stringify(event.error) : 'Unknown Error'
-            player_error_message: event.reason
+            player_error_message: event.error ? event.error : 'Unknown Error'
+            // player_error_message: event.reason
           });
           break;
         case cast.framework.events.EventType.RATE_CHANGE:

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,6 @@ const monitorChromecastPlayer = function (player, options) {
           }
           isPaused = false;
           player.mux.emit('playing');
-          console.log('STATS:' + new cast.framework.Stats());
           break;
         case cast.framework.events.EventType.ERROR:
           if (!options.automaticErrorTracking) { return; }
@@ -173,7 +172,9 @@ const monitorChromecastPlayer = function (player, options) {
         case cast.framework.events.EventType.TIME_UPDATE:
           currentTime = event.currentMediaTime;
           player.mux.emit('timeupdate');
-          console.log('STATS:' + new cast.framework.Stats());
+          let stats = new cast.framework.Stats();
+
+          console.log('WIDTH: ' + stats.width + ' / HEIGHT: ' + stats.height);
           break;
         case cast.framework.events.EventType.SEGMENT_DOWNLOADED:
           let now = Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -217,21 +217,18 @@ const monitorChromecastPlayer = function (player, options) {
     }
 
     if (inAdBreak === true) {
-      // Ad Events
-      // adpause event not present in chromecast documentation
       // chromecast will mix player messages with ad messages
-      // seperating out these ad events and supressing other messages until the adbreak is over
+      // seperating out these ad events and supressing unneeded messages until the adbreak is over
       switch (event.type) {
         case cast.framework.events.EventType.BREAK_CLIP_LOADING:
           if (adBreakClips !== null && event.breakClipId !== undefined) {
-            let obj = adBreakClips.find(o => o.id === event.breakClipId);
+            let breakClip = adBreakClips.find(o => o.id === event.breakClipId);
+            let adAssetUrl = (breakClip !== undefined && breakClip.contentUrl !== undefined) ? breakClip.contentUrl : (breakClip !== undefined && breakClip.contentId !== undefined) ? breakClip.contentId : null;
 
-            if (obj !== undefined && obj.contentUrl !== undefined) { var adAssetUrl = obj.contentUrl; } else { adAssetUrl = null; }
-            if (obj !== undefined && obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined) { var adTagUrl = obj.vastAdsRequest.adTagUrl; } else { adTagUrl = null; }
-
+            // Ad Tag URL is defined, but Chromecast does some weird auto-generated break clip stuff which doesn't carry the adTagUrl through to the generated breaks
+            // If google fix this, it can be added in the future
             player.mux.emit('adplay', {
-              ad_asset_url: adAssetUrl,
-              ad_tag_url: adTagUrl
+              ad_asset_url: adAssetUrl
             });
           } else {
             player.mux.emit('adplay');

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,7 @@ const monitorChromecastPlayer = function (player, options) {
           player.mux.emit('timeupdate');
           let stats = new cast.framework.Stats();
 
-          console.log('WIDTH: ' + stats.width + ' / HEIGHT: ' + stats.height);
+          console.log('STATS' + JSON.stringify(stats));
           break;
         case cast.framework.events.EventType.SEGMENT_DOWNLOADED:
           let now = Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,7 @@ const monitorChromecastPlayer = function (player, options) {
           }
           isPaused = false;
           player.mux.emit('playing');
+          console.log('STATS:' + new cast.framework.Stats());
           break;
         case cast.framework.events.EventType.ERROR:
           if (!options.automaticErrorTracking) { return; }
@@ -172,6 +173,7 @@ const monitorChromecastPlayer = function (player, options) {
         case cast.framework.events.EventType.TIME_UPDATE:
           currentTime = event.currentMediaTime;
           player.mux.emit('timeupdate');
+          console.log('STATS:' + new cast.framework.Stats());
           break;
         case cast.framework.events.EventType.SEGMENT_DOWNLOADED:
           let now = Date.now();
@@ -220,9 +222,6 @@ const monitorChromecastPlayer = function (player, options) {
   player.addEventListener(cast.framework.events.category.CORE, player.muxListener);
   player.addEventListener(cast.framework.events.category.FINE, player.muxListener);
   player.addEventListener(cast.framework.events.category.DEBUG, player.muxListener);
-  var stats = new cast.framework.Stats();
-
-  console.log(stats);
 
   // Lastly, initialize the tracking
   mux.init(playerID, options);

--- a/src/index.js
+++ b/src/index.js
@@ -164,10 +164,23 @@ const monitorChromecastPlayer = function (player, options) {
           break;
         case cast.framework.events.EventType.ERROR:
           if (!options.automaticErrorTracking) { return; }
-          player.mux.emit('error', {
-            player_error_code: event.detailedErrorCode,
-            player_error_message: event.error ? event.error.message : 'Unknown Error'
-          });
+          switch (event.detailedErrorCode) {
+            case 901:
+            case 902:
+              // specific errors to ads
+              player.mux.emit('aderror');
+              break;
+            case 903:
+            case 904:
+            // do nothing since these aren't fatal errors
+              break;
+            default:
+              player.mux.emit('error', {
+                player_error_code: event.detailedErrorCode,
+                player_error_message: event.error ? event.error.message : 'Unknown Error'
+              });
+              break;
+          }
           break;
         case cast.framework.events.EventType.RATE_CHANGE:
           player.mux.emit('ratechange');

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,12 @@ const monitorChromecastPlayer = function (player, options) {
     log.info('MuxCast: event ', event);
     if (inAdBreak === false) {
       switch (event.type) {
+        case cast.framework.messages.VideoInformation:
+          console.log('Video Information: ' + cast.framework.messages.VideoInformation);
+          break;
+        case cast.framework.Stats:
+          console.log('Stats: ' + cast.framework.Stats);
+          break;
         case cast.framework.events.EventType.REQUEST_LOAD:
           if (event.requestData.media !== undefined) {
             if (event.requestData.media.contentId !== undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,8 @@ const monitorChromecastPlayer = function (player, options) {
           videoChanged = false;
           break;
         case cast.framework.events.EventType.MEDIA_STATUS:
-          console.log('Stats: ' + cast.framework.Stats);
-          console.log('Video Information: ' + cast.framework.messages.VideoInformation);
+          console.log('Stats: ' + cast.framework.Stats.width + ' ' + cast.framework.Stats.height);
+          console.log('Video Information: ' + cast.framework.messages.VideoInformation.width + ' ' + cast.framework.messages.VideoInformation.height);
           if (event.mediaStatus.videoInfo !== undefined) {
             // Note: it appears the videoInfo field is always undefined
             videoSourceWidth = event.mediaStatus.videoInfo.width;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,9 @@ const generateShortId = function () {
 const monitorChromecastPlayer = function (player, options) {
   const defaults = {
     // Allow customers to be in full control of the "errors" that are fatal
-    automaticErrorTracking: true
+    automaticErrorTracking: true,
+    // Allow customers to emit videoChange, or set this to true for us to attempt to do this
+    automaticVideoChange: false
   };
 
   options = assign(defaults, options);
@@ -103,7 +105,7 @@ const monitorChromecastPlayer = function (player, options) {
 
           if (firstPlay) {
             firstPlay = false;
-          } else {
+          } else if (options.automaticVideoChange) {
             player.mux.emit('videochange', { video_title: title });
             videoChanged = true;
             player.mux.emit('ended');

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ const monitorChromecastPlayer = function (player, options) {
   };
 
   player.muxListener = function (event) {
-    // log.info('MuxCast: event ', event);
+    log.info('MuxCast: event ', event);
     if (inAdBreak === false) {
       switch (event.type) {
         case cast.framework.events.EventType.REQUEST_LOAD:
@@ -204,8 +204,7 @@ const monitorChromecastPlayer = function (player, options) {
           player.mux.emit('adplaying');
           break;
         case cast.framework.events.EventType.BREAK_CLIP_ENDED:
-          player.mux.emit('adended');
-          log.info('[mux] ENDED REASON: ' + event.endedReason);
+          event.endedReason && event.endedReason === 'ERROR' ? player.mux.emit('aderror') : player.mux.emit('adended');
           break;
         case cast.framework.events.EventType.BREAK_ENDED:
           player.mux.emit('adbreakend');

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,6 @@ const monitorChromecastPlayer = function (player, options) {
       player_is_paused: isPaused,
       video_source_width: videoSourceWidth,
       video_source_height: videoSourceHeight,
-      video_title: title,
       player_autoplay_on: autoplay,
       player_preload_on: undefined,
       video_source_url: mediaUrl,

--- a/src/index.js
+++ b/src/index.js
@@ -160,8 +160,7 @@ const monitorChromecastPlayer = function (player, options) {
           if (!options.automaticErrorTracking) { return; }
           player.mux.emit('error', {
             player_error_code: event.detailedErrorCode,
-            player_error_message: event.error ? event.error : 'Unknown Error'
-            // player_error_message: event.reason
+            player_error_message: event.error ? event.error.message : 'Unknown Error'
           });
           break;
         case cast.framework.events.EventType.RATE_CHANGE:

--- a/src/index.js
+++ b/src/index.js
@@ -226,8 +226,8 @@ const monitorChromecastPlayer = function (player, options) {
           if (adBreakClips !== null && event.breakClipId !== undefined) {
             let obj = adBreakClips.find(o => o.id === event.breakClipId);
 
-            if (obj.contentUrl !== undefined) { var adAssetUrl = obj.contentUrl; } else { adAssetUrl = undefined; }
-            if (obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined) { var adTagUrl = obj.vastAdsRequest.adTagUrl; } else { adTagUrl = undefined; }
+            if (obj !== undefined && obj.contentUrl !== undefined) { var adAssetUrl = obj.contentUrl; } else { adAssetUrl = null; }
+            if (obj !== undefined && obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined) { var adTagUrl = obj.vastAdsRequest.adTagUrl; } else { adTagUrl = null; }
 
             player.mux.emit('adplay', {
               ad_asset_url: adAssetUrl,

--- a/src/index.js
+++ b/src/index.js
@@ -181,6 +181,23 @@ const monitorChromecastPlayer = function (player, options) {
 
         player.mux.emit('requestcompleted', loadData);
         break;
+      // Ad Events
+      // adpause event not present in chromecast documentation
+      case cast.framework.events.EventType.BREAK_STARTED:
+        player.mux.emit('adbreakstart');
+        break;
+      case cast.framework.events.EventType.BREAK_CLIP_LOADING:
+        player.mux.emit('adplay');
+        break;
+      case cast.framework.events.EventType.BREAK_CLIP_STARTED:
+        player.mux.emit('adplaying');
+        break;
+      case cast.framework.events.EventType.BREAK_CLIP_ENDED:
+        player.mux.emit('adended');
+        break;
+      case cast.framework.events.EventType.BREAK_ENDED:
+        player.mux.emit('adbreakend');
+        break;
     }
   };
   player.addEventListener(cast.framework.events.category.CORE, player.muxListener);

--- a/src/index.js
+++ b/src/index.js
@@ -68,14 +68,14 @@ const monitorChromecastPlayer = function (player, options) {
       video_source_url: mediaUrl,
       video_source_mime_type: contentType,
       video_source_duration: duration,
-
+      viewer_device_name: 'Chromecast',
       video_poster_url: postUrl,
       player_language_code: undefined
     };
   };
 
   player.muxListener = function (event) {
-    log.info('MuxCast: event ', event);
+    // log.info('MuxCast: event ', event);
     if (inAdBreak === false) {
       switch (event.type) {
         case cast.framework.events.EventType.REQUEST_LOAD:
@@ -205,6 +205,8 @@ const monitorChromecastPlayer = function (player, options) {
           break;
         case cast.framework.events.EventType.BREAK_CLIP_ENDED:
           player.mux.emit('adended');
+          log.info('ENDED EVENT');
+          log.info(event);
           break;
         case cast.framework.events.EventType.BREAK_ENDED:
           player.mux.emit('adbreakend');

--- a/src/index.js
+++ b/src/index.js
@@ -226,9 +226,8 @@ const monitorChromecastPlayer = function (player, options) {
           if (adBreakClips !== null && event.breakClipId !== undefined) {
             let obj = adBreakClips.find(o => o.id === event.breakClipId);
 
-            var adAssetUrl = obj.contentUrl !== undefined ? obj.contentUrl : undefined;
-
-            if (obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined) { var adTagUrl = obj.vastAdsRequest.adTagUrl; } else { adTagUrl === undefined; }
+            if (obj.contentUrl !== undefined) { var adAssetUrl = obj.contentUrl; } else { adAssetUrl = undefined; }
+            if (obj.vastAdsRequest !== undefined && obj.vastAdsRequest.adTagUrl !== undefined) { var adTagUrl = obj.vastAdsRequest.adTagUrl; } else { adTagUrl = undefined; }
 
             player.mux.emit('adplay', {
               ad_asset_url: adAssetUrl,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,10 +3105,10 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-mux-embed@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-2.8.0.tgz#16ed2019b79f4fa775c828c09dd1ab57a4d75d10"
-  integrity sha512-GMMFDLKc1Z0m4szsq2tPTDDZ4BpkxZQcjdl26OGMmF0nTcO9LlispbCyy57Sqnd2mevnycLYKfhyjy24OsEl5g==
+mux-embed@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-3.0.0.tgz#2635706b5fe276deaaa57df4662f0daeb7ef0a31"
+  integrity sha512-7J4DYADNpYcGPz4JD7eHzwSMjbcGRIuchd6pZkBCUAk+ZP5m6t8KKbT6mg2G/oNo6ro+s+gIxLhPeH3i1B5bBw==
 
 nan@^2.9.2:
   version "2.10.0"


### PR DESCRIPTION
This PR includes:

- Tracking of ad events. This is messy since the player events and ad events overlap each other, and the dedicated ad events don't include events specific for ad errors or for an ad pause.

- Error codes are caught and emitted as either `aderror`, `error`, or ignored if the error isn't required to be known by Mux

- Added a Chromecast specific option for `automaticVideoChange` (default: `false`) which when enabled will automatically emit `videoChange` between playlist items. Otherwise, this should be done as part of the integration manually.

Investigated also the possibility of getting player width / height and source width / height. Chromecast is a mess here, and I have opened a ticket with support to try and get some of this working. This will need to come at a later date however.