### PR TITLE
Update video_source_url detection logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -7,10 +7,9 @@ var app = {
       debug: true,
       // automaticVideoChange: true,
       data: {
-        env_key: 'ikh9lsia6bh8pj5get2vnt6hm',
+        env_key: 'YOUR_ENV_KEY',
         player_init_time: Date.now(),
         video_title: 'ChromeCast Test Video',
-        experiment_name: 'Updated Source URL detection'
       }
     });
 

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -5,11 +5,11 @@ var app = {
 
     initChromecastMux(playerManager, {
       debug: true,
-      automaticVideoChange: true,
+      // automaticVideoChange: true,
       data: {
         env_key: 'YOUR_ENV_KEY',
         player_init_time: Date.now(),
-        experiment_name: 'automaticVideoChange enabled'
+        video_title: 'test'
       }
     });
 

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -7,9 +7,10 @@ var app = {
       debug: true,
       // automaticVideoChange: true,
       data: {
-        env_key: 'YOUR_ENV_KEY',
+        env_key: 'ikh9lsia6bh8pj5get2vnt6hm',
         player_init_time: Date.now(),
-        video_title: 'test'
+        video_title: 'ChromeCast Test Video',
+        experiment_name: 'Updated Source URL detection'
       }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ const monitorChromecastPlayer = function (player, options) {
       switch (event.type) {
         case cast.framework.events.EventType.REQUEST_LOAD:
           if (event.requestData.media !== undefined) {
-            if(event.requestData.media.contentUrl !== undefined) {
+            if (event.requestData.media.contentUrl !== undefined) {
               mediaUrl = event.requestData.media.contentUrl;
             } else if (event.requestData.media.contentId !== undefined) {
               mediaUrl = event.requestData.media.contentId;

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,9 @@ const monitorChromecastPlayer = function (player, options) {
       switch (event.type) {
         case cast.framework.events.EventType.REQUEST_LOAD:
           if (event.requestData.media !== undefined) {
-            if (event.requestData.media.contentId !== undefined) {
+            if(event.requestData.media.contentUrl !== undefined) {
+              mediaUrl = event.requestData.media.contentUrl;
+            } else if (event.requestData.media.contentId !== undefined) {
               mediaUrl = event.requestData.media.contentId;
             }
 


### PR DESCRIPTION
Chromecast can inform the current `video_source_url` in two places. Currently, we only check `contentId` but we should also check `contentUrl` (if defined) and let this one take precedence. 

https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.MediaInfo