### PR TITLE
Lowercase contentype to match other SDKs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ const monitorChromecastPlayer = function (player, options) {
             }
 
             if (event.requestData.media.contentType !== undefined) {
-              contentType = event.requestData.media.contentType;
+              contentType = event.requestData.media.contentType.toLowerCase();
             }
 
             if (event.requestData.media.metadata !== undefined) {


### PR DESCRIPTION
We should lowercase the content type value so that it better matches the other SDKs and will aggregated more consistently for reporting. 