### PR TITLE
Bump mux-embed & improve device detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",
@@ -31,7 +31,7 @@
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
     "global": "^4.3.0",
-    "mux-embed": "^3.0.0",
+    "mux-embed": "^4.0.0",
     "npm-run-all": "^2.2.0",
     "path": "^0.12.7",
     "sinon": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,10 @@ const getModelInfo = function () {
     const { hardwareConcurrency, userAgent } = window.navigator;
     const context = cast.framework.CastReceiverContext.getInstance();
 
-    // Android TV with Chromecast built-in
-    if (userAgent.includes('Android')) return 'Chromecast Built-In';
+    // Chromecast with Google TV supports 'H.264 High Profile, level 5.1'
+    if (context.canDisplayType('video/mp4; codecs="avc1.640033')) return 'Chromecast Google TV';
+    // Android Devices with Chromecast built-in
+    if (userAgent.includes('Android')) return 'Chromecast Android';
     // Chromecast Ultra supports 'HEVC main profile, level 3.1'
     if (context.canDisplayType('video/mp4; codecs=hev1.1.6.L93.B0')) return 'Chromecast Ultra';
     // 3rd generation Chromecast supports 'H.264 high profile, level 4.2'

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ const monitorChromecastPlayer = function (player, options) {
             }
 
             if (event.requestData.media.contentType !== undefined) {
-              contentType = event.requestData.media.contentType;
+              contentType = event.requestData.media.contentType.toLowerCase();
             }
 
             if (event.requestData.media.metadata !== undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const getModelInfo = function () {
     const context = cast.framework.CastReceiverContext.getInstance();
 
     // Chromecast with Google TV supports 'H.264 High Profile, level 5.1'
-    if (context.canDisplayType('video/mp4; codecs="avc1.640033')) return 'Chromecast Google TV';
+    if (context.canDisplayType('video/mp4; codecs="avc1.640033')) return 'Chromecast with Google TV';
     // Android Devices with Chromecast built-in
     if (userAgent.includes('Android')) return 'Chromecast Android';
     // Chromecast Ultra supports 'HEVC main profile, level 3.1'

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,27 @@ const generateShortId = function () {
   return ('000000' + (Math.random() * Math.pow(36, 6) << 0).toString(36)).slice(-6);
 };
 
+const getModelInfo = function () {
+  // https://developers.google.com/cast/docs/media#video_codecs
+  try {
+    const { hardwareConcurrency, userAgent } = window.navigator;
+    const context = cast.framework.CastReceiverContext.getInstance();
+
+    // Android TV with Chromecast built-in
+    if (userAgent.includes('Android')) return 'Chromecast Built-In';
+    // Chromecast Ultra supports 'HEVC main profile, level 3.1'
+    if (context.canDisplayType('video/mp4; codecs=hev1.1.6.L93.B0')) return 'Chromecast Ultra';
+    // 3rd generation Chromecast supports 'H.264 high profile, level 4.2'
+    if (context.canDisplayType('video/mp4; codecs=avc1.64002A')) return 'Chromecast 3';
+    // 2nd and 1st generation Chromecast can be differentiated by hardwareConcurrency
+    if (hardwareConcurrency === 2) return 'Chromecast 2';
+    if (hardwareConcurrency === 1) return 'Chromecast 1';
+  } catch (e) {
+      // do nothing
+  }
+  return 'Chromecast';
+};
+
 const monitorChromecastPlayer = function (player, options) {
   const defaults = {
     // Allow customers to be in full control of the "errors" that are fatal
@@ -23,7 +44,8 @@ const monitorChromecastPlayer = function (player, options) {
     player_software_name: 'Cast Application Framework Player',
     player_software_version: cast.framework.VERSION,
     player_mux_plugin_name: 'chromecast-mux',
-    player_mux_plugin_version: '[AIV]{version}[/AIV]'
+    player_mux_plugin_version: '[AIV]{version}[/AIV]',
+    viewer_device_name: getModelInfo()
   }, options.data);
 
   // Retrieve the ID and the player element
@@ -71,7 +93,6 @@ const monitorChromecastPlayer = function (player, options) {
       video_source_url: mediaUrl,
       video_source_mime_type: contentType,
       video_source_duration: duration,
-      viewer_device_name: 'Chromecast',
       video_poster_url: postUrl,
       player_language_code: undefined
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,10 +3105,10 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-mux-embed@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-3.0.0.tgz#2635706b5fe276deaaa57df4662f0daeb7ef0a31"
-  integrity sha512-7J4DYADNpYcGPz4JD7eHzwSMjbcGRIuchd6pZkBCUAk+ZP5m6t8KKbT6mg2G/oNo6ro+s+gIxLhPeH3i1B5bBw==
+mux-embed@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-4.0.0.tgz#7eec12990e458cb17146a64d5c09e56ce9cf44d3"
+  integrity sha512-Z1FrEExJWxi74B3KiPUvZjThmj09kJvmmlgzeePCT6LBi8oYNKQXbML4igHg2F/PP9bXRGtu4LQnsGuHOU2J4Q==
 
 nan@^2.9.2:
   version "2.10.0"


### PR DESCRIPTION
Thought this might be a good chance to improve the device detection client-side? I think even with the upgraded server-side detection, the only way to get the model of the chromecast is with the method included here. Would welcome thoughts!