### PR TITLE
mux-embed 4.1.1 and default player_remote_played to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
     "global": "^4.3.0",
-    "mux-embed": "^4.0.0",
+    "mux-embed": "^4.1.1",
     "npm-run-all": "^2.2.0",
     "path": "^0.12.7",
     "sinon": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ const monitorChromecastPlayer = function (player, options) {
     player_software_version: cast.framework.VERSION,
     player_mux_plugin_name: 'chromecast-mux',
     player_mux_plugin_version: '[AIV]{version}[/AIV]',
+    player_remote_played: true,
     viewer_device_name: getModelInfo()
   }, options.data);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,10 +3105,10 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-mux-embed@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-4.0.0.tgz#7eec12990e458cb17146a64d5c09e56ce9cf44d3"
-  integrity sha512-Z1FrEExJWxi74B3KiPUvZjThmj09kJvmmlgzeePCT6LBi8oYNKQXbML4igHg2F/PP9bXRGtu4LQnsGuHOU2J4Q==
+mux-embed@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-4.1.1.tgz#d61c297c6043c59793ec1837b778b294d60a66cd"
+  integrity sha512-AUjuWWRrKJ8byyd4vrZvLrA8yQGV3eoZ70u9n0HvA8AdY67xt+YBEAQbh5TYHEKfXLf1WpZlB9UScjgegUkrbQ==
 
 nan@^2.9.2:
   version "2.10.0"


### PR DESCRIPTION
 - Add support for custom dimensions via mux-embed update
 - Fix an issue where `player_remote_played` was unsettable, and default to `true`