### PR TITLE
Fix: allow manual videochanges to play nicely

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "4.0.0-beta.1",
+  "version": "3.1.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "3.1.0",
+  "version": "4.0.0-beta.1",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/sample_app/receiver/js/main.js
+++ b/sample_app/receiver/js/main.js
@@ -2,15 +2,27 @@ var app = {
   init: function () {
     const context = cast.framework.CastReceiverContext.getInstance();
     const playerManager = context.getPlayerManager();
+    let firstPlay = true;
+    let player_init_time = Date.now();
 
-    initChromecastMux(playerManager, {
-      debug: true,
-      // automaticVideoChange: true,
-      data: {
-        env_key: 'YOUR_ENV_KEY',
-        player_init_time: Date.now(),
-        video_title: 'ChromeCast Test Video',
+    playerManager.setMessageInterceptor(cast.framework.messages.MessageType.LOAD, loadRequestData => {
+      if (firstPlay) {
+        firstPlay = false;
+        initChromecastMux(playerManager, {
+          debug: true,
+          data: {
+            env_key: 'YOUR_ENV_KEY',
+            player_init_time: player_init_time,
+            video_title: 'Chromecast Test Video'
+          }
+        });
+      } else {
+        playerManager.mux.emit('videochange', {
+          video_title: 'Updated Video'
+        });
       }
+
+      return loadRequestData;
     });
 
     context.start();

--- a/src/index.js
+++ b/src/index.js
@@ -144,38 +144,34 @@ const monitorChromecastPlayer = function (player, options) {
     } else {
       // Not in an adbreak, regular playback monitoring
       switch (event.type) {
-        case cast.framework.events.EventType.REQUEST_LOAD:
+        case cast.framework.events.EventType.PLAYER_LOADING:
           // reset the playhead position as we're loading a new source
           currentTime = 0;
 
-          if (event.requestData.media !== undefined) {
-            if (event.requestData.media.contentUrl !== undefined) {
-              mediaUrl = event.requestData.media.contentUrl;
-            } else if (event.requestData.media.contentId !== undefined) {
-              mediaUrl = event.requestData.media.contentId;
+          if (event.media !== undefined) {
+            if (event.media.contentUrl !== undefined) {
+              mediaUrl = event.media.contentUrl;
+            } else if (event.media.contentId !== undefined) {
+              mediaUrl = event.media.contentId;
             }
 
-            if (event.requestData.media.contentType !== undefined) {
-              contentType = event.requestData.media.contentType.toLowerCase();
+            if (event.media.contentType !== undefined) {
+              contentType = event.media.contentType.toLowerCase();
             }
 
-            if (event.requestData.media.metadata !== undefined) {
-              if (event.requestData.media.metadata.images !== undefined && event.requestData.media.metadata.images.length > 0) {
-                postUrl = event.requestData.media.metadata.images[0].url;
+            if (event.media.metadata !== undefined) {
+              if (event.media.metadata.images !== undefined && event.media.metadata.images.length > 0) {
+                postUrl = event.media.metadata.images[0].url;
               }
             }
 
-            if (event.requestData.media.breakClips !== undefined) {
-              adBreakClips = event.requestData.media.breakClips;
+            if (event.media.breakClips !== undefined) {
+              adBreakClips = event.media.breakClips;
             }
-          }
-          if (event.requestData.autoplay !== undefined) {
-            autoplay = event.requestData.autoplay;
           }
 
           break;
         case cast.framework.events.EventType.LOAD_START:
-
           player.mux.emit('loadstart');
           player.mux.emit('play');
           break;

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ const monitorChromecastPlayer = function (player, options) {
   };
 
   player.muxListener = function (event) {
-    options.debug ? log.info('MuxCast: event ', event) : null;
+    log.info('MuxCast: event ', event);
 
     if (inAdBreak) {
       // Chromecast will mix player messages with ad messages

--- a/src/index.js
+++ b/src/index.js
@@ -180,19 +180,12 @@ const monitorChromecastPlayer = function (player, options) {
             autoplay = event.requestData.autoplay;
           }
 
-          if (options.automaticVideoChange === false && !firstPlay) {
-            // A video is already playing, but the user is changing to a new video
-            // without an automatic video change configured
-            // we need to let them set metadata first, and then have a play request get sent
-            // so short circuit this block to stop events getting sent too early
-            break;
-          }
-
           // the user is expecting us to detect video changes
           if (options.automaticVideoChange && !firstPlay) {
             player.mux.emit('videochange', { video_title: title });
           }
-
+          break;
+        case cast.framework.events.EventType.LOAD_START:
           firstPlay = false;
 
           player.mux.emit('loadstart');

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,12 @@ const monitorChromecastPlayer = function (player, options) {
         case cast.framework.events.EventType.ENDED:
           player.mux.emit('ended');
           break;
+        case cast.framework.events.EventType.MEDIA_FINISHED:
+          if (cast.framework.events.EndedReason.STOPPED === event.endedReason) {
+            isPaused = true;
+            player.mux.emit('pause');
+          }
+          break;
         case cast.framework.events.EventType.MEDIA_STATUS:
           if (event.mediaStatus.videoInfo !== undefined) {
             // Note: it appears the videoInfo field is always undefined

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ const monitorChromecastPlayer = function (player, options) {
   let videoSourceWidth = 0;
   let videoSourceHeight = 0;
   let firstPlay = true;
-  let videoChanged = false;
+  let videoChanged = true;
   let isSeeking = false;
   let inAdBreak = false;
   let adPlaying = false;
@@ -242,6 +242,7 @@ const monitorChromecastPlayer = function (player, options) {
           }
           isPaused = false;
           player.mux.emit('playing');
+          firstPlay = false;
           break;
         case cast.framework.events.EventType.ERROR:
           if (!options.automaticErrorTracking) { return; }

--- a/src/index.js
+++ b/src/index.js
@@ -150,14 +150,6 @@ const monitorChromecastPlayer = function (player, options) {
       // Not in an adbreak, regular playback monitoring
       switch (event.type) {
         case cast.framework.events.EventType.REQUEST_LOAD:
-          if (options.automaticVideoChange === false && !firstPlay) {
-            // A video is already playing, but the user is changing to a new video
-            // without an automatic video change configured
-            // we need to let them set metadata first, and then have a play request get sent
-            // so short circuit this block to stop events getting sent too early
-            videoChanged = true;
-            break;
-          }
           if (event.requestData.media !== undefined) {
             if (event.requestData.media.contentUrl !== undefined) {
               mediaUrl = event.requestData.media.contentUrl;
@@ -184,6 +176,15 @@ const monitorChromecastPlayer = function (player, options) {
           }
           if (event.requestData.autoplay !== undefined) {
             autoplay = event.requestData.autoplay;
+          }
+
+          if (options.automaticVideoChange === false && !firstPlay) {
+            // A video is already playing, but the user is changing to a new video
+            // without an automatic video change configured
+            // we need to let them set metadata first, and then have a play request get sent
+            // so short circuit this block to stop events getting sent too early
+            videoChanged = true;
+            break;
           }
 
           // the user is expecting us to detect video changes

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,7 @@ const getModelInfo = function () {
 const monitorChromecastPlayer = function (player, options) {
   const defaults = {
     // Allow customers to be in full control of the "errors" that are fatal
-    automaticErrorTracking: true,
-    // Allow customers to emit videoChange, or set this to true for us to attempt to do this
-    automaticVideoChange: false
+    automaticErrorTracking: true
   };
 
   options = assign(defaults, options);
@@ -62,7 +60,6 @@ const monitorChromecastPlayer = function (player, options) {
 
   let currentTime = 0;
   let autoplay;
-  let title;
   let mediaUrl;
   let contentType;
   let postUrl;
@@ -70,7 +67,6 @@ const monitorChromecastPlayer = function (player, options) {
   let isPaused = false;
   let videoSourceWidth = 0;
   let videoSourceHeight = 0;
-  let firstPlay = true;
   let isSeeking = false;
   let inAdBreak = false;
   let adPlaying = false;
@@ -164,9 +160,6 @@ const monitorChromecastPlayer = function (player, options) {
             }
 
             if (event.requestData.media.metadata !== undefined) {
-              if (event.requestData.media.metadata.title !== undefined) {
-                title = event.requestData.media.metadata.title;
-              }
               if (event.requestData.media.metadata.images !== undefined && event.requestData.media.metadata.images.length > 0) {
                 postUrl = event.requestData.media.metadata.images[0].url;
               }
@@ -180,13 +173,8 @@ const monitorChromecastPlayer = function (player, options) {
             autoplay = event.requestData.autoplay;
           }
 
-          // the user is expecting us to detect video changes
-          if (options.automaticVideoChange && !firstPlay) {
-            player.mux.emit('videochange', { video_title: title });
-          }
           break;
         case cast.framework.events.EventType.LOAD_START:
-          firstPlay = false;
 
           player.mux.emit('loadstart');
           player.mux.emit('play');
@@ -231,7 +219,6 @@ const monitorChromecastPlayer = function (player, options) {
           }
           isPaused = false;
           player.mux.emit('playing');
-          firstPlay = false;
           break;
         case cast.framework.events.EventType.ERROR:
           if (!options.automaticErrorTracking) { return; }

--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,14 @@ const monitorChromecastPlayer = function (player, options) {
       // Not in an adbreak, regular playback monitoring
       switch (event.type) {
         case cast.framework.events.EventType.REQUEST_LOAD:
+          if (options.automaticVideoChange === false && !firstPlay) {
+            // A video is already playing, but the user is changing to a new video
+            // without an automatic video change configured
+            // we need to let them set metadata first, and then have a play request get sent
+            // so short circuit this block to stop events getting sent too early
+            videoChanged = true;
+            break;
+          }
           if (event.requestData.media !== undefined) {
             if (event.requestData.media.contentUrl !== undefined) {
               mediaUrl = event.requestData.media.contentUrl;
@@ -180,7 +188,6 @@ const monitorChromecastPlayer = function (player, options) {
 
           // the user is expecting us to detect video changes
           if (options.automaticVideoChange && !firstPlay) {
-            player.mux.emit('ended');
             player.mux.emit('videochange', { video_title: title });
             videoChanged = true;
           }


### PR DESCRIPTION
In the case of manually controlling a videochange, the earliest event that can detect this is REQUEST_LOAD from the cast framework.

At present, we tie this to immediately start a new video by sending `loadstart` and `play`, however this doesn't in some situations give the user a chance to set metadata first.

This proposal is to handle videochanges and SDK initialisation through a load interceptor message.



```
let firstPlay = true;
let playerManager;

var app = {
  init: function () {
    const context = cast.framework.CastReceiverContext.getInstance();
    playerManager = context.getPlayerManager();
    context.start();
    
    playerManager.setMessageInterceptor(
      cast.framework.messages.MessageType.LOAD, loadRequestData => {

      // do interceptor things here

        if (firstPlay) {
            firstPlay = false;
            initChromecastMux(playerManager, {
              debug: true,
              data: {
                env_key: 'YOUR_ENV_KEY',
                video_title: 'First Video'
              }
            });
            
        } else {
          playerManager.mux.emit('videochange', {
              video_title: "Next Video"
           }); 
        }
        return loadRequestData;
    });

  }
};

$(document).ready(function () {
  app.init();
});
```

Other issues this PR addresses is where `ended` events can sometimes cause issues in view lifecycle by firing at the wrong time.