### PR TITLE
Fix destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecast-mux",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Chromecast",
   "main": "dist/chromecast-mux.js",

--- a/src/index.js
+++ b/src/index.js
@@ -278,17 +278,36 @@ const monitorChromecastPlayer = function (player, options) {
   mux.init(playerID, options);
   player.mux.emit('playerready');
 
-  player.mux.destroy = function () {
-    if (typeof player.muxListener !== 'undefined') {
-      player.removeEventListener(cast.framework.events.category.CORE, player.muxListener);
-      player.removeEventListener(cast.framework.events.category.FINE, player.muxListener);
-      player.removeEventListener(cast.framework.events.category.DEBUG, player.muxListener);
-      delete player.muxListener;
-      player.mux.emit('destroy');
-      player.mux.emit = function () {};
-      player.mux.destroy = function () {};
+  // Okay yes, this is silly. We originally introduced a weird ability to
+  // destroy a different player monitor than this one, so we're going to
+  // allow this for now. This should be changed to the below next time we
+  // major version bump this SDK.
+  player.mux.destroy = function (localPlayer) {
+    const playerToDestroy = localPlayer || player;
+
+    if (typeof playerToDestroy.muxListener !== 'undefined') {
+      playerToDestroy.removeEventListener(cast.framework.events.category.CORE, playerToDestroy.muxListener);
+      playerToDestroy.removeEventListener(cast.framework.events.category.FINE, playerToDestroy.muxListener);
+      playerToDestroy.removeEventListener(cast.framework.events.category.DEBUG, playerToDestroy.muxListener);
+      delete playerToDestroy.muxListener;
+      playerToDestroy.mux.emit('destroy');
+      playerToDestroy.mux.emit = function () {};
+      playerToDestroy.mux.destroy = function () {};
     }
   };
+
+  // NOTE: Use this when we next major version bump this SDK.
+  // player.mux.destroy = function () {
+  //   if (typeof player.muxListener !== 'undefined') {
+  //     player.removeEventListener(cast.framework.events.category.CORE, player.muxListener);
+  //     player.removeEventListener(cast.framework.events.category.FINE, player.muxListener);
+  //     player.removeEventListener(cast.framework.events.category.DEBUG, player.muxListener);
+  //     delete player.muxListener;
+  //     player.mux.emit('destroy');
+  //     player.mux.emit = function () {};
+  //     player.mux.destroy = function () {};
+  //   }
+  // };
 };
 
 export default monitorChromecastPlayer;

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ const monitorChromecastPlayer = function (player, options) {
   mux.init(playerID, options);
   player.mux.emit('playerready');
 
-  player.mux.destroy = function (player) {
+  player.mux.destroy = function () {
     if (typeof player.muxListener !== 'undefined') {
       player.removeEventListener(cast.framework.events.category.CORE, player.muxListener);
       player.removeEventListener(cast.framework.events.category.FINE, player.muxListener);


### PR DESCRIPTION
Previously we had a bug where `destroy` actually required you to pass the player in again, such as `player.mux.destroy(player)`. If you called this without passing in a `player` ref, it raises an exception. 

To be clear, it's odd to require a player ref to be passed in since it's something we already have. Instead, I decided to make it still function as it _used_ to, but fall back to use our player we hold internally instead of the one passed in, so it will work in both cases. We will want to remove this in the next major version release.